### PR TITLE
Update README.md

### DIFF
--- a/google_fonts/README.md
+++ b/google_fonts/README.md
@@ -72,7 +72,7 @@ You can also use `GoogleFonts.latoTextTheme()` to make or modify an entire text 
 MaterialApp(
   theme: ThemeData(
     textTheme: GoogleFonts.latoTextTheme(
-      Theme.of(context).textTheme,
+      textTheme: Theme.of(context).textTheme,
     ),
   ),
 );


### PR DESCRIPTION
The signature is `TextTheme latoTextTheme({TextTheme textTheme})`, so I think we need to name the parameter, correct?

Curious -- is the parameter necessary in this sample? I removed it on my app and didn't see any difference...