### PR TITLE
Update URLs to material-components.

### DIFF
--- a/web_benchmarks_example/pubspec.yaml
+++ b/web_benchmarks_example/pubspec.yaml
@@ -13,9 +13,8 @@ dependencies:
     sdk: flutter
   web_benchmarks_framework:
     git:
-      # TODO: update to the material-components repo, after #62 merges.
-      url: https://github.com/pennzht/material-components-flutter-experimental.git
-      ref: 9bc127b90d9c3844707fac2f9dbd764e60c04de5
+      url: https://github.com/material-components/material-components-flutter-experimental.git
+      ref: f6ebb4ed3b6489547d9ae58216df9999112be568
       path: web_benchmarks_framework
 
   cupertino_icons: ^0.1.3

--- a/web_benchmarks_framework/README.md
+++ b/web_benchmarks_framework/README.md
@@ -1,7 +1,7 @@
 # web_benchmarks_framework
 
 A minimal framework to run performance tests for flutter apps in Chrome.
-See [web_benchmarks_example](https://github.com/pennzht/material-components-flutter-experimental/tree/develop/web_benchmarks_example) for an example.
+See [web_benchmarks_example](https://github.com/material-components/material-components-flutter-experimental/tree/develop/web_benchmarks_example) for an example.
 
 This package is adapted from [macrobenchmarks](https://github.com/flutter/flutter/tree/master/dev/benchmarks/macrobenchmarks) and [devicelab](https://github.com/flutter/flutter/tree/master/dev/devicelab), the packages used by flutter to run performance tests in Chrome for the new Flutter Gallery.
 


### PR DESCRIPTION
Update URLs in `web_benchmarks_framework` and `web_benchmarks_example` to corresponding URLs in [material-components](https://github.com/material-components).