### PR TITLE
Fix ambiguous import.

### DIFF
--- a/adaptive_experimental/lib/scene2.dart
+++ b/adaptive_experimental/lib/scene2.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:flutter/material.dart' hide NavigationRail;
 import 'package:flutter/widgets.dart';
 
 import 'navigation_rail.dart';


### PR DESCRIPTION
The file `scene2.dart` in `adaptive_experimental` imports both `package:flutter/material.dart` and `navigation_rail.dart`. Both imports contain `NavigationRail`.

This PR resolves the ambiguous import.