### PR TITLE
Deprecate `web_benchmarks_framework` and update `web_benchmarks_example`

### DIFF
--- a/web_benchmarks_example/README.md
+++ b/web_benchmarks_example/README.md
@@ -2,4 +2,4 @@
 
 An example app for web benchmarks testing.
 
-This app demonstrates how to run performance tests in Chrome using the [web_benchmarks_framework](https://github.com/material-components/material-components-flutter-experimental/tree/develop/web_benchmarks_framework) package.
+This app demonstrates how to run performance tests in Chrome using the [web_benchmarks](https://pub.dev/packages/web_benchmarks) package.

--- a/web_benchmarks_example/lib/benchmarks/runner.dart
+++ b/web_benchmarks_example/lib/benchmarks/runner.dart
@@ -4,6 +4,7 @@
 
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:web_benchmarks/client.dart';
 import 'package:web_benchmarks_example/main.dart';
 import 'package:web_benchmarks_example/homepage.dart'
     show textKey, aboutPageKey;

--- a/web_benchmarks_example/lib/benchmarks/runner.dart
+++ b/web_benchmarks_example/lib/benchmarks/runner.dart
@@ -4,8 +4,6 @@
 
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:web_benchmarks_framework/recorder.dart';
-import 'package:web_benchmarks_framework/driver.dart';
 import 'package:web_benchmarks_example/main.dart';
 import 'package:web_benchmarks_example/homepage.dart'
     show textKey, aboutPageKey;

--- a/web_benchmarks_example/pubspec.yaml
+++ b/web_benchmarks_example/pubspec.yaml
@@ -11,7 +11,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  web_benchmarks: ^0.2.2
+  web_benchmarks: ^0.0.2
 
   cupertino_icons: ^0.1.3
 

--- a/web_benchmarks_example/pubspec.yaml
+++ b/web_benchmarks_example/pubspec.yaml
@@ -11,11 +11,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  web_benchmarks_framework:
-    git:
-      url: https://github.com/material-components/material-components-flutter-experimental.git
-      ref: f6ebb4ed3b6489547d9ae58216df9999112be568
-      path: web_benchmarks_framework
+  web_benchmarks: ^0.2.2
 
   cupertino_icons: ^0.1.3
 

--- a/web_benchmarks_example/test/run_benchmarks.dart
+++ b/web_benchmarks_example/test/run_benchmarks.dart
@@ -1,10 +1,11 @@
 import 'dart:convert' show JsonEncoder;
+import 'dart:io';
 
 import 'package:web_benchmarks/server.dart';
 
 Future<void> main() async {
-  final taskResult = await runWebBenchmark(
-    macrobenchmarksDirectory: '.',
+  final taskResult = await serveWebBenchmark(
+    benchmarkAppDirectory: Directory('.'),
     entryPoint: 'lib/benchmarks/runner.dart',
     useCanvasKit: false,
   );

--- a/web_benchmarks_example/test/run_benchmarks.dart
+++ b/web_benchmarks_example/test/run_benchmarks.dart
@@ -1,6 +1,6 @@
 import 'dart:convert' show JsonEncoder;
 
-import 'package:web_benchmarks_framework/server.dart';
+import 'package:web_benchmarks/server.dart';
 
 Future<void> main() async {
   final taskResult = await runWebBenchmark(

--- a/web_benchmarks_framework/README.md
+++ b/web_benchmarks_framework/README.md
@@ -1,4 +1,4 @@
 # web_benchmarks_framework
 
 This package is deprecated.
-Please use [web_benchmarks](https://pub.dev/packages?q=web_benchmarks) instead.
+Please use [web_benchmarks](https://pub.dev/packages/web_benchmarks) instead.

--- a/web_benchmarks_framework/README.md
+++ b/web_benchmarks_framework/README.md
@@ -1,7 +1,4 @@
 # web_benchmarks_framework
 
-A minimal framework to run performance tests for flutter apps in Chrome.
-See [web_benchmarks_example](https://github.com/material-components/material-components-flutter-experimental/tree/develop/web_benchmarks_example) for an example.
-
-This package is adapted from [macrobenchmarks](https://github.com/flutter/flutter/tree/master/dev/benchmarks/macrobenchmarks) and [devicelab](https://github.com/flutter/flutter/tree/master/dev/devicelab), the packages used by flutter to run performance tests in Chrome for the new Flutter Gallery.
-
+This package is deprecated.
+Please use [web_benchmarks](https://pub.dev/packages?q=web_benchmarks) instead.


### PR DESCRIPTION
## Overview
* This PR deprecates `web_benchmarks_framework`, a temporary package added for demonstration purposes.
* All references to `web_benchmarks_framework` are updated to [`web_benchmarks`](https://pub.dev/packages/web_benchmarks), the pub.dev package.

## Question
* Should we remove `web_benchmarks_framework` altogether?
